### PR TITLE
Fix filename (uploaded file isn't a path-able object)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 
 .venv*
 .pdm-python
+
+.direnv/

--- a/src/vizzu_builder/data/generator.py
+++ b/src/vizzu_builder/data/generator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from .configurator import DataConfig
 
@@ -22,7 +21,7 @@ class DataGenerator:
             else:
                 d_types.append(f'"{column}": float')
         code.append(f'd_types={{{", ".join(d_types)}}}')
-        code.append(f'df = pd.read_csv("{Path(config.csv_file).name}", dtype=d_types)')
+        code.append(f'df = pd.read_csv("{config.csv_file.name}", dtype=d_types)')
         code.append("data = Data()")
         code.append("data.add_df(df)\n")
         return code


### PR DESCRIPTION
Fixes the bug currently in the app 
<img width="1708" alt="image" src="https://github.com/vizzu-streamlit/vizzu-builder/assets/4040678/51e600ee-a911-472f-86f4-1e34633b42f7">
